### PR TITLE
feature : #57 민원 생성 이미지 추가

### DIFF
--- a/src/main/java/com/fixplz/complaint/application/controller/ComplaintController.java
+++ b/src/main/java/com/fixplz/complaint/application/controller/ComplaintController.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/complaint")
@@ -23,7 +25,7 @@ public class ComplaintController {
     private final MessageService messageService;
 
     @PostMapping("")
-    public ResponseEntity<ApiResponse> createComplaint(@RequestBody CreateComplaintRequest request) {
+    public ResponseEntity<ApiResponse> createComplaint(@ModelAttribute CreateComplaintRequest request) throws IOException {
 
         CreateComplaintResponse response = complaintService.createComplaint(request);
 

--- a/src/main/java/com/fixplz/complaint/application/dto/request/CreateComplaintRequest.java
+++ b/src/main/java/com/fixplz/complaint/application/dto/request/CreateComplaintRequest.java
@@ -1,13 +1,17 @@
 package com.fixplz.complaint.application.dto.request;
 
+import org.springframework.web.multipart.MultipartFile;
+
 public record CreateComplaintRequest (
+        MultipartFile image,
         String complaintContent,
         int filterCategory,
         String phoneNumber,
         Long facilityNo
 ) {
-    public static CreateComplaintRequest of(String complaintContent, int filterCategory, String phoneNumber, Long facilityNo) {
+    public static CreateComplaintRequest of(MultipartFile image, String complaintContent, int filterCategory, String phoneNumber, Long facilityNo) {
         return new CreateComplaintRequest(
+                image,
                 complaintContent,
                 filterCategory,
                 phoneNumber,

--- a/src/main/java/com/fixplz/complaint/application/dto/request/CreateComplaintRequest.java
+++ b/src/main/java/com/fixplz/complaint/application/dto/request/CreateComplaintRequest.java
@@ -18,4 +18,14 @@ public record CreateComplaintRequest (
                 facilityNo
         );
     }
+
+    public static CreateComplaintRequest exceptImage(String complaintContent, int filterCategory, String phoneNumber, Long facilityNo) {
+        return new CreateComplaintRequest(
+                null,
+                complaintContent,
+                filterCategory,
+                phoneNumber,
+                facilityNo
+        );
+    }
 }

--- a/src/main/java/com/fixplz/complaint/application/dto/response/GetComplaintResponse.java
+++ b/src/main/java/com/fixplz/complaint/application/dto/response/GetComplaintResponse.java
@@ -1,7 +1,6 @@
 package com.fixplz.complaint.application.dto.response;
 
 import com.fixplz.complaint.domain.aggregate.entity.Complaint;
-import com.fixplz.facility.domain.aggregate.enumtype.FacilityCategory;
 
 import java.text.SimpleDateFormat;
 

--- a/src/main/java/com/fixplz/complaint/application/service/ComplaintService.java
+++ b/src/main/java/com/fixplz/complaint/application/service/ComplaintService.java
@@ -41,7 +41,7 @@ public class ComplaintService {
         String complaintImageUrl = "none";
 
         // 이미지 처리
-        if (!request.image().isEmpty()) {
+        if (request.image() != null) {
             complaintImageUrl = s3Service.uploadComplaintImage(request.image(), request.phoneNumber());
         }
 

--- a/src/main/java/com/fixplz/complaint/application/service/ComplaintService.java
+++ b/src/main/java/com/fixplz/complaint/application/service/ComplaintService.java
@@ -9,19 +9,17 @@ import com.fixplz.complaint.domain.aggregate.vo.FilterCategory;
 import com.fixplz.complaint.domain.aggregate.vo.ProcessingStatus;
 import com.fixplz.complaint.domain.repository.ComplaintRepository;
 import com.fixplz.complaint.infra.service.ComplaintInfraService;
-import com.fixplz.facility.domain.aggregate.enumtype.FacilityCategory;
+import com.fixplz.complaint.infra.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.Serializable;
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Service
@@ -30,16 +28,22 @@ public class ComplaintService {
 
     private final ComplaintRepository complaintRepository;
     private final ComplaintInfraService complaintInfraService;
+    private final S3Service s3Service;
 
     // 민원 생성
     @Transactional
-    public CreateComplaintResponse createComplaint(CreateComplaintRequest request) {
+    public CreateComplaintResponse createComplaint(CreateComplaintRequest request) throws IOException {
 
         FilterCategory filterCategory = FilterCategory.fromInt(request.filterCategory());
 
         FacilityNoVO facilityNoVO = new FacilityNoVO(request.facilityNo());
 
-        // 이미지 처리?
+        String complaintImageUrl = "none";
+
+        // 이미지 처리
+        if (!request.image().isEmpty()) {
+            complaintImageUrl = s3Service.uploadComplaintImage(request.image(), request.phoneNumber());
+        }
 
         Complaint complaint = new Complaint.Builder()
                 .complaintContent(request.complaintContent())
@@ -48,6 +52,7 @@ public class ComplaintService {
                 .filterCategory(filterCategory)
                 .facilityNoVO(facilityNoVO)
                 .processingStatus(ProcessingStatus.TODO)
+                .complaintImage(complaintImageUrl)
                 .build();
 
         Complaint createdComplaint = complaintRepository.save(complaint);
@@ -112,7 +117,6 @@ public class ComplaintService {
                 .toList();
 
         GetComplaintPageInfo response = new GetComplaintPageInfo(facilityInfo, filterCategoryList);
-        System.out.println("response = " + response);
 
         return response;
     }

--- a/src/main/java/com/fixplz/complaint/infra/service/ComplaintInfraService.java
+++ b/src/main/java/com/fixplz/complaint/infra/service/ComplaintInfraService.java
@@ -2,7 +2,6 @@ package com.fixplz.complaint.infra.service;
 
 import com.fixplz.common.annotation.InfraService;
 import com.fixplz.complaint.application.dto.response.GetFacilityInfo;
-import com.fixplz.facility.application.service.FacilityService;
 import com.fixplz.facility.domain.aggregate.entity.Facility;
 import com.fixplz.facility.domain.repository.FacilityRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/fixplz/complaint/infra/service/S3Service.java
+++ b/src/main/java/com/fixplz/complaint/infra/service/S3Service.java
@@ -1,0 +1,25 @@
+package com.fixplz.complaint.infra.service;
+
+import com.fixplz.common.annotation.InfraService;
+import com.fixplz.common.utils.S3Storage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+@InfraService
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Storage s3StorageService;
+
+    public String uploadComplaintImage(MultipartFile image, String phoneNumber) throws IOException {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+        String date = simpleDateFormat.format(new Date());
+        String fileName = phoneNumber.substring(6, 10) + date + "complaint-image";
+
+        return s3StorageService.uploadFile(image, "complaint", fileName);
+    }
+}

--- a/src/test/java/com/fixplz/complaint/application/service/ComplaintServiceTests.java
+++ b/src/test/java/com/fixplz/complaint/application/service/ComplaintServiceTests.java
@@ -22,7 +22,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.Date;
 
 @SpringBootTest
@@ -92,7 +94,7 @@ class ComplaintServiceTests {
     @Test
     @Transactional
     @DisplayName("민원 생성 : success")
-    void createComplaint() {
+    void createComplaint() throws IOException {
 
 
         // given
@@ -102,7 +104,7 @@ class ComplaintServiceTests {
         Long facilityNo = 1L;
         // 이미지 추가
 
-        CreateComplaintRequest request = new CreateComplaintRequest(complaintContent, filterCategory, phoneNumber, facilityNo);
+        CreateComplaintRequest request = CreateComplaintRequest.exceptImage(complaintContent, filterCategory, phoneNumber, facilityNo);
 
         // when
         long beforeCnt = complaintRepository.count();


### PR DESCRIPTION
# ✨#57 민원 생성 이미지 추가
- closed #57
<!-- 이슈 번호는 꼭 함께 적어주세요. -->

# ✏️내용
- 민원 생성 시 이미지를 받아서 s3에 저장하도록 기능 추가
  - 이미지 받아서 s3에 저장, url을 반환받아서 저장
# 📸스크린샷

# 🎁참고사항
